### PR TITLE
Handle specific decode errors

### DIFF
--- a/tests/test_live.py
+++ b/tests/test_live.py
@@ -1,3 +1,4 @@
+import base64
 import unittest
 from unittest.mock import Mock
 
@@ -24,6 +25,15 @@ class TestWebSocket(unittest.TestCase):
     def test_decode_message_invalid(self):
         websocket = BaseWebSocket(Mock())
         base64_message = "invalid_base64_string"
+        decoded = websocket._decode_message(base64_message)
+        assert "error" in decoded
+        assert "raw_base64" in decoded
+        self.assertEqual(base64_message, decoded["raw_base64"])
+
+    def test_decode_message_invalid_proto(self):
+        websocket = BaseWebSocket(Mock())
+        raw = b"not a valid proto"
+        base64_message = base64.b64encode(raw).decode()
         decoded = websocket._decode_message(base64_message)
         assert "error" in decoded
         assert "raw_base64" in decoded


### PR DESCRIPTION
## Summary
- distinguish base64 and protobuf decoding failures in `_decode_message`
- add test for invalid protobuf message

## Testing
- `pytest tests/test_live.py`
- `pytest` *(fails: ProxyError, unable to open database file)*

------
https://chatgpt.com/codex/tasks/task_e_688fb9ecbc00832491159377f4f3ebaf