### PR TITLE
Avoid heartbeat when WebSocket has no subscriptions

### DIFF
--- a/yfinance/live.py
+++ b/yfinance/live.py
@@ -72,12 +72,14 @@ class AsyncWebSocket(BaseWebSocket):
             try:
                 await asyncio.sleep(self._subscription_interval)
 
-                if self._subscriptions:
-                    message = {"subscribe": list(self._subscriptions)}
-                    await self._ws.send(json.dumps(message))
+                if not self._subscriptions:
+                    continue
 
-                    if self.verbose:
-                        print(f"Heartbeat subscription sent for symbols: {self._subscriptions}")
+                message = {"subscribe": list(self._subscriptions)}
+                await self._ws.send(json.dumps(message))
+
+                if self.verbose:
+                    print(f"Heartbeat subscription sent for symbols: {self._subscriptions}")
             except Exception as e:
                 self.logger.error("Error in heartbeat subscription: %s", e, exc_info=True)
                 if self.verbose:


### PR DESCRIPTION
## Summary
- Skip heartbeat messages in `_periodic_subscribe` when no symbols are subscribed

## Testing
- `python -m pytest tests/test_live.py::TestWebSocket -q`
- `python -m pytest -q` *(fails: TestCacheNoPermission.test_tzCacheRootLookup)*

------
https://chatgpt.com/codex/tasks/task_e_688fb9edcce883249dc1b949bed979c1