### PR TITLE
Use dict.fromkeys to preserve ticker order

### DIFF
--- a/yfinance/multi.py
+++ b/yfinance/multi.py
@@ -141,7 +141,7 @@ def download(tickers, start=None, end=None, actions=False, threads=True,
 
     tickers = _tickers_
 
-    tickers = list(set([ticker.upper() for ticker in tickers]))
+    tickers = list(dict.fromkeys([ticker.upper() for ticker in tickers]))
 
     if progress:
         shared._PROGRESS_BAR = utils.ProgressBar(len(tickers), 'completed')


### PR DESCRIPTION
## Summary
- Preserve ticker input order by deduplicating with `dict.fromkeys`

## Testing
- `pytest tests/test_lookup.py::TestLookup::test_get_stock -q` *(fails: ProxyError)*

------
https://chatgpt.com/codex/tasks/task_e_688fb9d230f8832491a8322f536b6b72