### PR TITLE
Add thread locks to shared structures

### DIFF
--- a/yfinance/shared.py
+++ b/yfinance/shared.py
@@ -19,8 +19,15 @@
 # limitations under the License.
 #
 
+import threading
+
 _DFS = {}
+_DFS_LOCK = threading.Lock()
 _PROGRESS_BAR = None
+_PROGRESS_BAR_LOCK = threading.Lock()
 _ERRORS = {}
+_ERRORS_LOCK = threading.Lock()
 _TRACEBACKS = {}
+_TRACEBACKS_LOCK = threading.Lock()
 _ISINS = {}
+_ISINS_LOCK = threading.Lock()


### PR DESCRIPTION
## Summary
- add threading locks for shared caches and state
- guard threaded downloads and result processing with lock context

## Testing
- `pytest` *(fails: peewee.OperationalError: unable to open database file)*

------
https://chatgpt.com/codex/tasks/task_e_688fb9d67b4c8324b24c8bc2aad23264