### PR TITLE
feat: enhance error reporting

### DIFF
--- a/yfinance/exceptions.py
+++ b/yfinance/exceptions.py
@@ -51,3 +51,37 @@ class YFInvalidPeriodError(YFException):
 class YFRateLimitError(YFException):
     def __init__(self):
         super().__init__("Too Many Requests. Rate limited. Try after a while.")
+
+
+class YFRequestError(YFException):
+    def __init__(self, url, message="", original_exception=None):
+        self.url = url
+        self.message = message
+        self.original_exception = original_exception
+        detail = message if message else "Request error"
+        detail += f" for url {url}"
+        if original_exception is not None:
+            detail += f" ({original_exception})"
+        super().__init__(detail)
+
+
+class YFHTTPError(YFRequestError):
+    def __init__(self, url, status_code, response_text=""):
+        msg = f"HTTP {status_code}"
+        if response_text:
+            msg += f": {response_text}"
+        super().__init__(url, msg)
+        self.status_code = status_code
+        self.response_text = response_text
+
+
+class YFConnectionError(YFRequestError):
+    def __init__(self, url, original_exception=None):
+        super().__init__(url, "Connection error", original_exception)
+
+
+class YFTimeoutError(YFRequestError):
+    def __init__(self, url, timeout, original_exception=None):
+        message = f"Request timed out after {timeout} seconds"
+        super().__init__(url, message, original_exception)
+        self.timeout = timeout

--- a/yfinance/lookup.py
+++ b/yfinance/lookup.py
@@ -91,8 +91,11 @@ class Lookup:
             data = {}
 
         # Error returned
-        if data.get("finance", {}).get("error", {}):
-            raise YFException(data.get("finance", {}).get("error", {}))
+        error = data.get("finance", {}).get("error", {})
+        if error:
+            desc = error.get("description", error)
+            code = error.get("code", "unknown")
+            raise YFException(f"{desc} (code: {code}). Full error: {error}")
 
         self._cache[cache_key] = data
         return data

--- a/yfinance/scrapers/analysis.py
+++ b/yfinance/scrapers/analysis.py
@@ -171,11 +171,18 @@ class Analysis:
     # modified version from quote.py
     def _fetch(self, modules: list):
         if not isinstance(modules, list):
-            raise YFException("Should provide a list of modules, see available modules using `valid_modules`")
+            raise YFException(
+                "Should provide a list of modules, see available modules using `valid_modules`. "
+                f"Received {modules!r} of type {type(modules).__name__}"
+            )
 
+        original_modules = modules
         modules = ','.join([m for m in modules if m in quote_summary_valid_modules])
         if len(modules) == 0:
-            raise YFException("No valid modules provided, see available modules using `valid_modules`")
+            raise YFException(
+                "No valid modules provided, see available modules using `valid_modules`. "
+                f"Requested modules: {original_modules}"
+            )
         params_dict = {"modules": modules, "corsDomain": "finance.yahoo.com", "formatted": "false", "symbol": self._symbol}
         try:
             result = self._data.get_raw_json(_QUOTE_SUMMARY_URL_ + f"/{self._symbol}", params=params_dict)

--- a/yfinance/scrapers/funds.py
+++ b/yfinance/scrapers/funds.py
@@ -193,7 +193,7 @@ class FundsData:
             self._parse_top_holdings(data["topHoldings"])
             self._parse_fund_profile(data["fundProfile"])
         except KeyError:
-            raise YFDataException("No Fund data found.")
+            raise YFDataException(f"No Fund data found for '{self._symbol}'.")
         except Exception as e:
             logger = utils.get_yf_logger()
             logger.error(f"Failed to get fund data for '{self._symbol}' reason: {e}")

--- a/yfinance/scrapers/holders.py
+++ b/yfinance/scrapers/holders.py
@@ -98,7 +98,7 @@ class Holders:
             self._parse_insider_holders(data.get("insiderHolders", {}))
             self._parse_net_share_purchase_activity(data.get("netSharePurchaseActivity", {}))
         except (KeyError, IndexError):
-            raise YFDataException("Failed to parse holders json data.")
+            raise YFDataException(f"Failed to parse holders json data for '{self._symbol}'.")
 
     @staticmethod
     def _parse_raw_values(data):

--- a/yfinance/scrapers/quote.py
+++ b/yfinance/scrapers/quote.py
@@ -580,11 +580,18 @@ class Quote:
 
     def _fetch(self, modules: list):
         if not isinstance(modules, list):
-            raise YFException("Should provide a list of modules, see available modules using `valid_modules`")
+            raise YFException(
+                "Should provide a list of modules, see available modules using `valid_modules`. "
+                f"Received {modules!r} of type {type(modules).__name__}"
+            )
 
+        original_modules = modules
         modules = ','.join([m for m in modules if m in quote_summary_valid_modules])
         if len(modules) == 0:
-            raise YFException("No valid modules provided, see available modules using `valid_modules`")
+            raise YFException(
+                "No valid modules provided, see available modules using `valid_modules`. "
+                f"Requested modules: {original_modules}"
+            )
         params_dict = {"modules": modules, "corsDomain": "finance.yahoo.com", "formatted": "false", "symbol": self._symbol}
         try:
             result = self._data.get_raw_json(_QUOTE_SUMMARY_URL_ + f"/{self._symbol}", params=params_dict)


### PR DESCRIPTION
## Summary
- introduce detailed request-related exceptions
- surface clearer request and JSON parsing errors
- enrich module validation and fund/holder parsing messages

## Testing
- `pytest -q` *(fails: curl_cffi.requests.exceptions.ProxyError)*

------
https://chatgpt.com/codex/tasks/task_e_68904f0aed188324ac9aeb9758298de4