### PR TITLE
Log blank OHLC timestamps in parse_quotes

### DIFF
--- a/yfinance/utils.py
+++ b/yfinance/utils.py
@@ -511,6 +511,13 @@ def parse_quotes(data):
     quotes.index = _pd.to_datetime(timestamps, unit="s")
     quotes.sort_index(inplace=True)
 
+    all_nan = quotes[["Open", "High", "Low", "Close"]].isna().all(axis=1)
+    if all_nan.any():
+        logger = get_yf_logger()
+        logger.debug(
+            f"Received blank OHLC for timestamps: {quotes.index[all_nan][:5].tolist()}"
+        )
+
     return quotes
 
 


### PR DESCRIPTION
## Summary
- debug blank OHLC rows in parse_quotes by logging first few timestamps

## Testing
- `python -m py_compile yfinance/utils.py`

------
https://chatgpt.com/codex/tasks/task_e_6891ee87fe2c83249fc1ba3aaebe18bb