### PR TITLE
Retry empty Yahoo Finance history rows

### DIFF
--- a/tests/test_retry_empty_rows.py
+++ b/tests/test_retry_empty_rows.py
@@ -1,0 +1,85 @@
+import pandas as pd
+import yfinance as yf
+from yfinance.data import YfData
+from yfinance.scrapers.history import PriceHistory
+
+class MockResponse:
+    def __init__(self, json_data):
+        self._json = json_data
+        self.text = ""
+    def json(self):
+        return self._json
+
+
+def test_retry_empty_rows(monkeypatch):
+    meta = {
+        "instrumentType": "EQUITY",
+        "exchangeTimezoneName": "UTC",
+        "currency": "USD",
+    }
+    json_missing = {
+        "chart": {
+            "result": [
+                {
+                    "meta": meta,
+                    "timestamp": [0, 86400],
+                    "indicators": {
+                        "quote": [
+                            {
+                                "open": [None, 1.0],
+                                "high": [None, 1.0],
+                                "low": [None, 1.0],
+                                "close": [None, 1.0],
+                                "volume": [0, 1],
+                            }
+                        ],
+                        "adjclose": [{"adjclose": [None, 1.0]}],
+                    },
+                    "events": {},
+                }
+            ],
+            "error": None,
+        }
+    }
+    json_filled = {
+        "chart": {
+            "result": [
+                {
+                    "meta": meta,
+                    "timestamp": [0],
+                    "indicators": {
+                        "quote": [
+                            {
+                                "open": [1.0],
+                                "high": [1.0],
+                                "low": [1.0],
+                                "close": [1.0],
+                                "volume": [1],
+                            }
+                        ],
+                        "adjclose": [{"adjclose": [1.0]}],
+                    },
+                    "events": {},
+                }
+            ],
+            "error": None,
+        }
+    }
+
+    responses = [MockResponse(json_missing), MockResponse(json_filled)]
+    call = {"n": 0}
+
+    def fake_get(**kwargs):
+        resp = responses[call["n"]]
+        call["n"] = min(call["n"] + 1, len(responses) - 1)
+        return resp
+
+    data = YfData()
+    monkeypatch.setattr(data, "get", fake_get)
+    monkeypatch.setattr(data, "cache_get", fake_get)
+
+    ph = PriceHistory(data, "TEST", tz="UTC")
+    df = ph.history(start="1970-01-01", end="1970-01-03", interval="1d", actions=False, auto_adjust=False, keepna=True)
+
+    assert not df.iloc[0].isna().all()
+    assert len(df) == 2

--- a/yfinance/scrapers/history.py
+++ b/yfinance/scrapers/history.py
@@ -35,7 +35,7 @@ class PriceHistory:
                 start=None, end=None, prepost=False, actions=True,
                 auto_adjust=True, back_adjust=False, repair=False, keepna=False,
                 proxy=_SENTINEL_, rounding=False, timeout=10,
-                raise_errors=False, _no_cache=False) -> pd.DataFrame:
+                raise_errors=False, _no_cache=False, _retry=True) -> pd.DataFrame:
         """
         :Parameters:
             period : str
@@ -521,6 +521,40 @@ class PriceHistory:
                     mask_nan_or_zero = mask_refetch
                     interval = interval_user
                     intraday = interval[-1] in ("m", 'h')
+        # Retry fetching rows that are entirely empty
+        if _retry and mask_nan_or_zero.any():
+            interval_td = utils._interval_to_timedelta(interval_user)
+            idx_bad = mask_nan_or_zero.index[mask_nan_or_zero]
+            for dt in idx_bad:
+                start_dt = dt - interval_td
+                end_dt = dt + interval_td
+                for _ in range(3):
+                    df_retry = self.history(
+                        start=start_dt,
+                        end=end_dt,
+                        interval=interval_user,
+                        prepost=prepost,
+                        actions=actions,
+                        auto_adjust=auto_adjust,
+                        back_adjust=back_adjust,
+                        repair=repair,
+                        keepna=True,
+                        rounding=rounding,
+                        timeout=timeout,
+                        raise_errors=raise_errors,
+                        _no_cache=True,
+                        _retry=False,
+                    )
+                    if df_retry.empty or dt not in df_retry.index:
+                        continue
+                    row = df_retry.loc[[dt]]
+                    if (row[data_colnames].isna() | (row[data_colnames] == 0)).all(axis=1).iloc[0]:
+                        continue
+                    for col in row.columns:
+                        if col in df.columns:
+                            df.at[dt, col] = row[col].iloc[0]
+                    break
+            mask_nan_or_zero = (df[data_colnames].isna() | (df[data_colnames] == 0)).all(axis=1)
         if keepna:
             if mask_nan_or_zero.any():
                 logger.warning(


### PR DESCRIPTION
## Summary
- retry empty rows in `PriceHistory.history`
- add unit test for retrying blank rows

## Testing
- `pytest tests/test_retry_empty_rows.py -q`
- `pytest tests/test_prices.py::TestPriceHistory::test_daily_index -q` *(fails: ProxyError: Failed to perform, CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68920aa7993083248285dc66ec745127