### PR TITLE
feat: limit history retry attempts

### DIFF
--- a/yfinance/scrapers/history.py
+++ b/yfinance/scrapers/history.py
@@ -35,7 +35,7 @@ class PriceHistory:
                 start=None, end=None, prepost=False, actions=True,
                 auto_adjust=True, back_adjust=False, repair=False, keepna=False,
                 proxy=_SENTINEL_, rounding=False, timeout=10,
-                raise_errors=False, _no_cache=False, _retry=True) -> pd.DataFrame:
+                raise_errors=False, max_retries=5, _no_cache=False, _retry=True) -> pd.DataFrame:
         """
         :Parameters:
             period : str
@@ -76,6 +76,10 @@ class PriceHistory:
               | Default: 10 seconds
             raise_errors : bool
                 If True, then raise errors as Exceptions instead of logging.
+            max_retries : int
+                Maximum attempts to refill empty rows when Yahoo returns
+                completely missing price data.
+                Default: 5
         """
         logger = utils.get_yf_logger()
 
@@ -524,38 +528,44 @@ class PriceHistory:
         # Retry fetching rows that are entirely empty
         if _retry and mask_nan_or_zero.any():
             interval_td = utils._interval_to_timedelta(interval_user)
-            while mask_nan_or_zero.any():
-                idx_bad = mask_nan_or_zero.index[mask_nan_or_zero]
-                for dt in idx_bad:
-                    start_dt = dt - interval_td
-                    end_dt = dt + interval_td
-                    while True:
-                        df_retry = self.history(
-                            start=start_dt,
-                            end=end_dt,
-                            interval=interval_user,
-                            prepost=prepost,
-                            actions=actions,
-                            auto_adjust=auto_adjust,
-                            back_adjust=back_adjust,
-                            repair=repair,
-                            keepna=True,
-                            rounding=rounding,
-                            timeout=timeout,
-                            raise_errors=raise_errors,
-                            _no_cache=True,
-                            _retry=False,
-                        )
-                        if df_retry.empty or dt not in df_retry.index:
-                            continue
-                        row = df_retry.loc[[dt]]
-                        if (row[data_colnames].isna() | (row[data_colnames] == 0)).all(axis=1).iloc[0]:
-                            continue
-                        for col in row.columns:
-                            if col in df.columns:
-                                df.at[dt, col] = row[col].iloc[0]
-                        break
-                mask_nan_or_zero = (df[data_colnames].isna() | (df[data_colnames] == 0)).all(axis=1)
+            idx_bad = mask_nan_or_zero.index[mask_nan_or_zero]
+            for dt in idx_bad:
+                start_dt = dt - interval_td
+                end_dt = dt + interval_td
+                for _ in range(max_retries):
+                    df_retry = self.history(
+                        start=start_dt,
+                        end=end_dt,
+                        interval=interval_user,
+                        prepost=prepost,
+                        actions=actions,
+                        auto_adjust=auto_adjust,
+                        back_adjust=back_adjust,
+                        repair=repair,
+                        keepna=True,
+                        rounding=rounding,
+                        timeout=timeout,
+                        raise_errors=raise_errors,
+                        _no_cache=True,
+                        _retry=False,
+                    )
+                    if df_retry.empty or dt not in df_retry.index:
+                        continue
+                    row = df_retry.loc[[dt]]
+                    if (row[data_colnames].isna() | (row[data_colnames] == 0)).all(axis=1).iloc[0]:
+                        continue
+                    for col in row.columns:
+                        if col in df.columns:
+                            df.at[dt, col] = row[col].iloc[0]
+                    break
+                else:
+                    logger.debug(
+                        "%s: exceeded max_retries=%d for %s",
+                        self.ticker,
+                        max_retries,
+                        dt,
+                    )
+            mask_nan_or_zero = (df[data_colnames].isna() | (df[data_colnames] == 0)).all(axis=1)
         if keepna:
             if mask_nan_or_zero.any():
                 logger.warning(


### PR DESCRIPTION
## Summary
- add max_retries option to PriceHistory.history to cap repeated fetches for empty rows
- stop infinite looping by attempting each row up to a limited number of times and logging when exceeded

## Testing
- `python -m pytest` *(fails: curl_cffi.requests.exceptions.ProxyError, peewee.OperationalError)*

------
https://chatgpt.com/codex/tasks/task_e_6892211367b48324bf70d9a62b06fcef