### PR TITLE
Use curl_cffi requests Session in history scraper

### DIFF
--- a/yfinance/scrapers/history.py
+++ b/yfinance/scrapers/history.py
@@ -9,7 +9,6 @@ import numpy as np
 import pandas as pd
 import time as _time
 import warnings
-import requests
 
 from yfinance import shared, utils
 from yfinance.const import _BASE_URL_, _PRICE_COLNAMES_, _SENTINEL_


### PR DESCRIPTION
## Summary
- Drop standard `requests` import from history scraper
- Ensure history sessions rely on `curl_cffi.requests.Session` so impersonation works

## Testing
- `pytest -q` *(fails: ProxyError, peewee OperationalError; 109 failed, 36 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68944c4f1cbc8324acf3b6d3b917669d