### PR TITLE
Remove unused exceptions import in history scraper

### DIFF
--- a/yfinance/scrapers/history.py
+++ b/yfinance/scrapers/history.py
@@ -1,5 +1,4 @@
 from curl_cffi import requests
-from curl_cffi.requests import exceptions as req_exceptions
 from math import isclose
 import bisect
 import datetime as _datetime
@@ -9,19 +8,11 @@ import numpy as np
 import pandas as pd
 import time as _time
 import warnings
-import requests
 
-from yfinance import shared, utils
+from yfinance import utils
 from yfinance.const import _BASE_URL_, _PRICE_COLNAMES_, _SENTINEL_
 from yfinance.exceptions import (
-    YFInvalidPeriodError,
     YFPricesMissingError,
-    YFTzMissingError,
-    YFRateLimitError,
-    YFRequestError,
-    YFHTTPError,
-    YFConnectionError,
-    YFTimeoutError,
 )
 
 _SECONDS_IN_DAY = 86400


### PR DESCRIPTION
## Summary
- trim unused imports in `history.py`
- remove unused curl_cffi exceptions import

## Testing
- `ruff check yfinance/scrapers/history.py --select F401`
- `pytest tests/test_cache.py::TestCache::test_storeTzNoRaise -q`


------
https://chatgpt.com/codex/tasks/task_e_68944c4ff7e88324a0ed446b6bde649e