### PR TITLE
refactor: use _re alias for price regex

### DIFF
--- a/yfinance/utils.py
+++ b/yfinance/utils.py
@@ -178,10 +178,8 @@ def enable_debug_mode():
 def is_isin(string):
     return bool(_re.match("^([A-Z]{2})([A-Z0-9]{9})([0-9])$", string))
 
-import re
-
-_PRICE_RE = re.compile(
-    r"^(open|high|low|close|adj[_\s]?close|price|adjclose)$", re.I
+_PRICE_RE = _re.compile(
+    r"^(open|high|low|close|adj[_\s]?close|price|adjclose)$", _re.I
 )
 
 def _get_price_columns(df: _pd.DataFrame) -> list[str]:


### PR DESCRIPTION
## Summary
- remove unused `import re`
- build price column regex with `_re`

## Testing
- `pytest` *(fails: curl_cffi.requests.exceptions.ProxyError, etc. 109 failed, 36 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68944c57a11c8324bd5f5b7bc53f980f