### PR TITLE
refactor: remove unused canonical names set

### DIFF
--- a/yfinance/utils.py
+++ b/yfinance/utils.py
@@ -234,12 +234,6 @@ def _df_stats(
 
     # 2. Определяем ценовые колонки
     if price_cols is None:
-        canonical_names = {
-            "open", "high", "low", "close", "adj close",
-            "adjclose", "adj_close",
-            "open_price", "high_price", "low_price", "close_price",
-            "adj_close_price"
-        }
         price_cols = _get_price_columns(frame)
 
     # 3. Считаем «нулевые» строки


### PR DESCRIPTION
## Summary
- remove unused canonical_names set from _df_stats

## Testing
- `pip install -r requirements.txt`
- `pytest` *(fails: ProxyError during network requests, sqlite OperationalError, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68944c5f5d6083248c1f66428cc58634